### PR TITLE
Bump rack version max

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.2.2
+  - 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
   - 2.2.2
-  - 2.3

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Hoe.spec 'marlowe' do
   license 'MIT'
 
   extra_deps << ['request_store', '~> 1.2']
-  extra_deps << ['rack',  '>= 0.9', '< 2']
+  extra_deps << ['rack',  '>= 0.9', '< 3']
 
   extra_dev_deps << ['rack-test', '~> 0.6']
   self.extra_dev_deps << ['rake', '~> 10.0']

--- a/marlowe.gemspec
+++ b/marlowe.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<request_store>, ["~> 1.2"])
-      s.add_runtime_dependency(%q<rack>, ["< 2", ">= 0.9"])
+      s.add_runtime_dependency(%q<rack>, ["< 3", ">= 0.9"])
       s.add_development_dependency(%q<minitest>, ["~> 5.8"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<rack-test>, ["~> 0.6"])
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<hoe>, ["~> 3.14"])
     else
       s.add_dependency(%q<request_store>, ["~> 1.2"])
-      s.add_dependency(%q<rack>, ["< 2", ">= 0.9"])
+      s.add_dependency(%q<rack>, ["< 3", ">= 0.9"])
       s.add_dependency(%q<minitest>, ["~> 5.8"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<rack-test>, ["~> 0.6"])
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<request_store>, ["~> 1.2"])
-    s.add_dependency(%q<rack>, ["< 2", ">= 0.9"])
+    s.add_dependency(%q<rack>, ["< 3", ">= 0.9"])
     s.add_dependency(%q<minitest>, ["~> 5.8"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<rack-test>, ["~> 0.6"])


### PR DESCRIPTION
Marlowe seems to be compatible with Rack 2, so this PR just bumps the version limit.  This allows it to be used with Rails 5, which requires Rack 2.
