### PR TITLE
Update dependencies and add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,13 +21,13 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
+          - '3.3'
           - head
           - jruby
           - jruby-head
           - truffleruby
           - truffleruby-head
-          - truffleruby+graalvm
-          - truffleruby+graalvm-head
         include:
           - ruby: head
             continue-on-error: true
@@ -36,7 +36,9 @@ jobs:
           - os: ubuntu-22.04
             ruby: head
           - os: ubuntu-22.04
-            ruby: '3.1'
+            ruby: '3.2'
+          - os: ubuntu-22.04
+            ruby: '3.3'
 
     runs-on: ${{ matrix.os }}
 
@@ -52,4 +54,6 @@ jobs:
       - run: bundle exec ruby -S rake test --trace
       - run: bundle exec ruby -S appraisal install
       - run: bundle exec ruby -S appraisal rake test
+
       - run: bundle exec standardrb
+        if: ${{ matrix.ruby == '3.3' && matrix.os == 'ubuntu-22.04' }}

--- a/Appraisals
+++ b/Appraisals
@@ -2,12 +2,10 @@
 
 appraise "rack-1" do
   gem "rack", "~> 1.6"
-  gem "rack-test", "~> 1.0"
 end
 
 appraise "rack-2" do
   gem "rack", "~> 2.0"
-  gem "rack-test", "~> 1.0"
 end
 
 appraise "rack-3" do

--- a/History.md
+++ b/History.md
@@ -1,17 +1,24 @@
-### 3.0 / 2022-09-11
+# History
+
+## 3.1 / 2024-02-29
+
+- Fixed some noise in the tests as preparation for Rack 3.1.
+- Updated dependencies.
+
+## 3.0 / 2022-09-11
 
 - Added a Faraday request middleware.
 - Replaced Hurley example with examples for the use of the Faraday
   middleware.
 - Added global Marlowe configuration.
 
-### 2.1 / 2021-09-08
+## 2.1 / 2021-09-08
 
 - Allow the use of Ruby 3.
 - Switch to standardruby instead of rubocop.
 - Switch from Travis to Github Actions.
 
-### 2.0 / 2016-11-16
+## 2.0 / 2016-11-16
 
 - Breaking change: the correlation header defaults to `X-Request-Id` instead of
   `Correlation-Id`.
@@ -22,21 +29,21 @@
   part of the response.
 - Marlowe is more configurable now.
 
-### 1.0.3 / 2016-01-15
+## 1.0.3 / 2016-01-15
 
 - Update Readme example of using available formatted subclass.
 - Make the correlation header name configurable
 
-### 1.0.2 / 2015-11-24
+## 1.0.2 / 2015-11-24
 
 - Add documentation for using Marlowe with [lograge][].
 
-### 1.0.1 / 2015-10-20
+## 1.0.1 / 2015-10-20
 
 - Update gemspec with homepage
 - Update Rakefile
 
-### 1.0.0 / 2015-10-16
+## 1.0.0 / 2015-10-16
 
 - Initial Commit
 

--- a/Rakefile
+++ b/Rakefile
@@ -28,19 +28,16 @@ spec = Hoe.spec "marlowe" do
   extra_dev_deps << ["appraisal", "~> 2.1"]
   extra_dev_deps << ["hoe-doofus", "~> 1.0"]
   extra_dev_deps << ["hoe-gemspec2", "~> 1.1"]
-  extra_dev_deps << ["hoe-git", "~> 1.6"]
+  extra_dev_deps << ["hoe-git2", "~> 1.7"]
   extra_dev_deps << ["hoe-rubygems", "~> 1.0"]
   extra_dev_deps << ["minitest", "~> 5.4"]
   extra_dev_deps << ["minitest-autotest", "~> 1.0"]
-  extra_dev_deps << ["minitest-bonus-assertions", "~> 3.0"]
   extra_dev_deps << ["minitest-focus", "~> 1.1"]
   extra_dev_deps << ["minitest-moar", "~> 0.0"]
   extra_dev_deps << ["rack-test", "~> 2.0"]
   extra_dev_deps << ["rake", ">= 10.0", "< 14"]
-  extra_dev_deps << ["rdoc", ">= 4.2"]
   extra_dev_deps << ["standard", "~> 1.0"]
   extra_dev_deps << ["simplecov", "~> 0.21"]
-  extra_dev_deps << ["psych", "~> 3.1"]
 end
 
 ENV["RUBYOPT"] = "-W0"

--- a/gemfiles/rack_1.gemfile
+++ b/gemfiles/rack_1.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org/"
 
 gem "rack", "~> 1.6"
-gem "rack-test", "~> 1.0"
 
 gemspec path: "../"

--- a/gemfiles/rack_2.gemfile
+++ b/gemfiles/rack_2.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org/"
 
 gem "rack", "~> 2.0"
-gem "rack-test", "~> 1.0"
 
 gemspec path: "../"

--- a/lib/marlowe.rb
+++ b/lib/marlowe.rb
@@ -2,7 +2,7 @@
 
 # Marlowe, a correlation id injector.
 module Marlowe
-  VERSION = "3.0" # :nodoc:
+  VERSION = "3.1" # :nodoc:
 
   require "marlowe/config"
   require "marlowe/middleware"

--- a/marlowe.gemspec
+++ b/marlowe.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.metadata = { "documentation_uri" => "http://www.rubydoc.info/github/KineticCafe/marlowe/master", "source_code_uri" => "https://github.com/KineticCafe/marlowe/" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Trevor Oke".freeze, "Kinetic Cafe".freeze]
-  s.date = "2022-09-12"
+  s.date = "2024-02-27"
   s.description = "{Marlowe}[https://github.com/KineticCafe/marlowe] is a Rack middleware that\nextracts or creates a request ID using a pre-defined header, permitting request\ncorrelation across multiple services.\n\nWhen using Rails, Marlowe automatically adds itself to the middleware before\n<tt>Rails::Rack::Logger</tt>.\n\nAs of Marlowe 3.0, a Faraday middleware is provided (<tt>require 'marlowe/faraday'</tt>).".freeze
   s.email = ["toke@kineticcafe.com".freeze, "dev@kineticcafe.com".freeze]
   s.extra_rdoc_files = ["Contributing.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]
@@ -18,52 +18,26 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
   s.required_ruby_version = Gem::Requirement.new([">= 2.0".freeze, "< 4".freeze])
-  s.rubygems_version = "3.3.7".freeze
+  s.rubygems_version = "3.4.10".freeze
   s.summary = "{Marlowe}[https://github.com/KineticCafe/marlowe] is a Rack middleware that extracts or creates a request ID using a pre-defined header, permitting request correlation across multiple services".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<request_store>.freeze, ["~> 1.2"])
-    s.add_runtime_dependency(%q<rack>.freeze, [">= 1", "< 4"])
-    s.add_development_dependency(%q<minitest>.freeze, ["~> 5.16"])
-    s.add_development_dependency(%q<appraisal>.freeze, ["~> 2.1"])
-    s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
-    s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
-    s.add_development_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
-    s.add_development_dependency(%q<rack-test>.freeze, ["~> 2.0"])
-    s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_development_dependency(%q<rdoc>.freeze, [">= 4.2"])
-    s.add_development_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.21"])
-    s.add_development_dependency(%q<psych>.freeze, ["~> 3.1"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.25"])
-  else
-    s.add_dependency(%q<request_store>.freeze, ["~> 1.2"])
-    s.add_dependency(%q<rack>.freeze, [">= 1", "< 4"])
-    s.add_dependency(%q<minitest>.freeze, ["~> 5.16"])
-    s.add_dependency(%q<appraisal>.freeze, ["~> 2.1"])
-    s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 3.0"])
-    s.add_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
-    s.add_dependency(%q<rack-test>.freeze, ["~> 2.0"])
-    s.add_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_dependency(%q<rdoc>.freeze, [">= 4.2"])
-    s.add_dependency(%q<standard>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<simplecov>.freeze, ["~> 0.21"])
-    s.add_dependency(%q<psych>.freeze, ["~> 3.1"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.25"])
-  end
+  s.add_runtime_dependency(%q<request_store>.freeze, ["~> 1.2"])
+  s.add_runtime_dependency(%q<rack>.freeze, [">= 1", "< 4"])
+  s.add_development_dependency(%q<minitest>.freeze, ["~> 5.22"])
+  s.add_development_dependency(%q<appraisal>.freeze, ["~> 2.1"])
+  s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
+  s.add_development_dependency(%q<hoe-git2>.freeze, ["~> 1.7"])
+  s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
+  s.add_development_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
+  s.add_development_dependency(%q<rack-test>.freeze, ["~> 2.0"])
+  s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
+  s.add_development_dependency(%q<standard>.freeze, ["~> 1.0"])
+  s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.21"])
+  s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
+  s.add_development_dependency(%q<hoe>.freeze, ["~> 4.2"])
 end

--- a/test/minitest_config.rb
+++ b/test/minitest_config.rb
@@ -9,3 +9,29 @@ require "minitest/focus"
 require "minitest/moar"
 
 require "marlowe"
+
+RackV1 = Rack.release.start_with?("1.")
+
+module NormalizeRackResponseHeaders
+  private
+
+  def has_header?(key)
+    if RackV1
+      last_response.header.key?(key)
+    else
+      last_response.has_header?(key)
+    end
+  end
+
+  def get_header(key)
+    if RackV1
+      last_response.header[key]
+    else
+      last_response.get_header(key)
+    end
+  end
+end
+
+class Minitest::Test
+  include NormalizeRackResponseHeaders
+end

--- a/test/test_marlowe.rb
+++ b/test/test_marlowe.rb
@@ -29,75 +29,75 @@ class TestMarlowe < Minitest::Test
 
   def test_default_config_no_header_value
     get "/"
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
   end
 
   def test_default_config_with_header_value
     get "/", {}, {"HTTP_X_REQUEST_ID" => "testvalue"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "testvalue", get_header("X-Request-Id")
   end
 
   def test_header_config_no_header_value
     marlowe_options[:header] = "Correlation-Id"
     get "/"
-    assert last_response.header.key?("Correlation-Id")
-    refute_empty last_response.header["Correlation-Id"]
-    assert_equal last_response.header["Correlation-Id"], last_response.body
+    assert has_header?("Correlation-Id")
+    refute_empty get_header("Correlation-Id")
+    assert_equal get_header("Correlation-Id"), last_response.body
   end
 
   def test_header_config_no_header_with_header_value
     marlowe_options[:header] = "Correlation-Id"
     get "/", {}, {"HTTP_CORRELATION_ID" => "testvalue"}
-    assert last_response.header.key?("Correlation-Id")
-    refute_empty last_response.header["Correlation-Id"]
-    assert_equal last_response.header["Correlation-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["Correlation-Id"]
+    assert has_header?("Correlation-Id")
+    refute_empty get_header("Correlation-Id")
+    assert_equal get_header("Correlation-Id"), last_response.body
+    assert_equal "testvalue", get_header("Correlation-Id")
   end
 
   def test_handler_config_default_handler
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "testvalue", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_simple_handler
     marlowe_options[:handler] = :simple
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "test+value", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "test+value", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_proc_handler
     marlowe_options[:handler] = ->(item) { item && item.reverse || SecureRandom.uuid }
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "eulav+tset", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "eulav+tset", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_proc_handler_returning_nil
     marlowe_options[:handler] = ->(_item) {}
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_match(/\A[-\w]+\z/, last_response.header["X-Request-Id"])
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_match(/\A[-\w]+\z/, get_header("X-Request-Id"))
   end
 
   def test_return_config_false
     marlowe_options[:return] = false
     get "/"
-    refute last_response.header.key?("X-Request-Id")
+    refute has_header?("X-Request-Id")
     assert_equal RequestStore[:correlation_id], last_response.body
   end
 end

--- a/test/test_marlowe_config.rb
+++ b/test/test_marlowe_config.rb
@@ -35,75 +35,76 @@ class TestMarloweConfig < Minitest::Test
 
   def test_default_config_no_header_value
     get "/"
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
+
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
   end
 
   def test_default_config_with_header_value
     get "/", {}, {"HTTP_X_REQUEST_ID" => "testvalue"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "testvalue", get_header("X-Request-Id")
   end
 
   def test_header_config_no_header_value
     marlowe_options[:header] = "Correlation-Id"
     get "/"
-    assert last_response.header.key?("Correlation-Id")
-    refute_empty last_response.header["Correlation-Id"]
-    assert_equal last_response.header["Correlation-Id"], last_response.body
+    assert has_header?("Correlation-Id")
+    refute_empty get_header("Correlation-Id")
+    assert_equal get_header("Correlation-Id"), last_response.body
   end
 
   def test_header_config_no_header_with_header_value
     marlowe_options[:header] = "Correlation-Id"
     get "/", {}, {"HTTP_CORRELATION_ID" => "testvalue"}
-    assert last_response.header.key?("Correlation-Id")
-    refute_empty last_response.header["Correlation-Id"]
-    assert_equal last_response.header["Correlation-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["Correlation-Id"]
+    assert has_header?("Correlation-Id")
+    refute_empty get_header("Correlation-Id")
+    assert_equal get_header("Correlation-Id"), last_response.body
+    assert_equal "testvalue", get_header("Correlation-Id")
   end
 
   def test_handler_config_default_handler
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "testvalue", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "testvalue", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_simple_handler
     marlowe_options[:handler] = :simple
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "test+value", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "test+value", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_proc_handler
     marlowe_options[:handler] = ->(item) { item && item.reverse || SecureRandom.uuid }
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_equal "eulav+tset", last_response.header["X-Request-Id"]
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_equal "eulav+tset", get_header("X-Request-Id")
   end
 
   def test_handler_config_with_proc_handler_returning_nil
     marlowe_options[:handler] = ->(_item) {}
     get "/", {}, {"HTTP_X_REQUEST_ID" => "test+value"}
-    assert last_response.header.key?("X-Request-Id")
-    refute_empty last_response.header["X-Request-Id"]
-    assert_equal last_response.header["X-Request-Id"], last_response.body
-    assert_match(/\A[-\w]+\z/, last_response.header["X-Request-Id"])
+    assert has_header?("X-Request-Id")
+    refute_empty get_header("X-Request-Id")
+    assert_equal get_header("X-Request-Id"), last_response.body
+    assert_match(/\A[-\w]+\z/, get_header("X-Request-Id"))
   end
 
   def test_return_config_false
     marlowe_options[:return] = false
     get "/"
-    refute last_response.header.key?("X-Request-Id")
+    refute has_header?("X-Request-Id")
     assert_equal RequestStore[:correlation_id], last_response.body
   end
 end


### PR DESCRIPTION
- Expanded tests to include Ruby 3.3 and removing the +graalvm variants.
- Removed `rack-test ~> 1.0` from appraisal configuration.